### PR TITLE
Fix UserDefaults setValue→set and URL plist-safe handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,22 @@ The macros natively support these types with optimized `UserDefaults` methods:
 
 All primitive types can be optional (e.g., `String?`, `Int?`). Optional types return `nil` when no value is stored.
 
+### `URL` Storage
+
+`URL` is stored via `UserDefaults.set(_:URL?, forKey:)` and read via `url(forKey:)`, which round-trips through `NSKeyedArchiver`. Because `URL` is *not* a property-list type, it cannot be passed to `register(defaults:)`. When you supply a `defaultValue:` for a non-optional `URL`, the generated getter falls back to it via `??` instead:
+
+```swift
+@UserDefaultDataStore
+struct API {
+    @UserDefaultRecord(defaultValue: URL(string: "https://api.example.com")!)
+    var endpoint: URL
+}
+```
+Generated getter:
+```swift
+userDefaults.url(forKey: "endpoint") ?? URL(string: "https://api.example.com")!
+```
+
 ### Custom Types
 
 Custom types (classes, structs, enums) are supported through `UserDefaults`' `object(forKey:)` method, which requires types to conform to:

--- a/Sources/UserDefault/UserDefault.swift
+++ b/Sources/UserDefault/UserDefault.swift
@@ -58,7 +58,7 @@ public macro UserDefaultDataStore(using userDefaults: UserDefaults = .standard, 
 ///     @UserDefaultRecord(key: "isInitialLaunch", defaultValue: true)
 ///     var isFirstTimeLaunching: Bool {
 ///         get { userDefaults.bool(forKey: "isInitialLaunch") }
-///         set { userDefaults.setValue(newValue, forKey: "isInitialLaunch") }
+///         set { userDefaults.set(newValue, forKey: "isInitialLaunch") }
 ///     }
 ///
 ///     private let userDefaults: UserDefaults
@@ -135,7 +135,7 @@ public macro UserDefaultRecord<T, C: UserDefaultsCoding>(key: String? = nil, def
 ///         return UserDefaults.test.string(forKey: Self.key)!
 ///     }
 ///     set {
-///         UserDefaults.test.setValue(newValue, forKey: Self.key)
+///         UserDefaults.test.set(newValue, forKey: Self.key)
 ///     }
 /// }
 /// ```

--- a/Sources/UserDefaultMacro/Extensions/AccessorMacro+Extensions.swift
+++ b/Sources/UserDefaultMacro/Extensions/AccessorMacro+Extensions.swift
@@ -24,7 +24,7 @@ extension AccessorMacro {
         let (variableName, variableType) = try extractVariableInfo(from: variableDecl)
         let key = userDefinedKey ?? variableName.withDoubleQuotes
 
-        if !variableType.isPlistSafe {
+        if variableType.needsCoding {
             if let codingExpression {
                 return codableAccessors(
                     variableType: variableType,
@@ -89,17 +89,20 @@ extension AccessorMacro {
         skipRegistering: Bool,
         userDefaultsString: String
     ) -> [AccessorDeclSyntax] {
-        let registerPrefix: String
-        if !skipRegistering, let defaultValue {
-            registerPrefix = "\(userDefaultsString).register(defaults: [\(key): \(defaultValue)])\nreturn "
+        let methodCall = "\(userDefaultsString).\(variableType.userDefaultsMethodName)(forKey: \(key))"
+
+        let getterBody: String
+        if case .url = variableType, let defaultValue {
+            // URL isn't plist-safe and can't be registered. Use ?? fallback instead of force-unwrap.
+            getterBody = "\(methodCall) ?? \(defaultValue)"
+        } else if !skipRegistering, let defaultValue, variableType.isPlistSafe {
+            getterBody =
+                "\(userDefaultsString).register(defaults: [\(key): \(defaultValue)])\nreturn \(methodCall)\(variableType.castExpressionIfNeeded())"
         } else {
-            registerPrefix = ""
+            getterBody = "\(methodCall)\(variableType.castExpressionIfNeeded())"
         }
-        let castSuffix = variableType.castExpressionIfNeeded()
-        return [
-            "get { \(raw: registerPrefix)\(raw: userDefaultsString).\(raw: variableType.userDefaultsMethodName)(forKey: \(raw: key))\(raw: castSuffix) }",
-            "set { \(raw: userDefaultsString).setValue(newValue, forKey: \(raw: key)) }",
-        ]
+
+        return ["get { \(raw: getterBody) }", "set { \(raw: userDefaultsString).set(newValue, forKey: \(raw: key)) }"]
     }
 
     private static func codableAccessors(

--- a/Sources/UserDefaultMacro/Models/VariableType.swift
+++ b/Sources/UserDefaultMacro/Models/VariableType.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SwiftSyntax
 
-indirect enum VariableType: CaseIterable {
+indirect enum VariableType: CaseIterable, Sendable {
     static let allCases: [VariableType] = [
         .int, .double, .float, .bool, .string, .url, .data, .date, .array(elementType: .int),
         .dictionary(keyType: .int, valueType: .int), .object(entityTypeName: "SomeEntityName"),
@@ -65,11 +65,29 @@ indirect enum VariableType: CaseIterable {
 
     var isPlistSafe: Bool {
         switch self {
-        case .int, .double, .float, .bool, .string, .data, .url, .date: true
+        case .int, .double, .float, .bool, .string, .data, .date: true
+        // URL is not a property-list type. `UserDefaults.set(_:URL?, forKey:)` archives it as
+        // Data, but `register(defaults:)` rejects non-plist values. Excluding URL routes it
+        // through the `?? default` fallback in the getter instead of being registered.
+        case .url: false
         case .array(let elementType): elementType.isPlistSafe
         case .dictionary(let keyType, let valueType): keyType.isPlistSafe && valueType.isPlistSafe
         case .optional(let wrappedType): wrappedType.isPlistSafe
         case .object: false
+        }
+    }
+
+    /// Whether the type needs a `coding:` strategy to be stored in UserDefaults.
+    ///
+    /// Distinct from `isPlistSafe`: `URL` isn't plist-safe (so it can't be `register`-ed) but
+    /// has a native `url(forKey:)` accessor, so it does *not* need Codable encoding.
+    var needsCoding: Bool {
+        switch self {
+        case .object: true
+        case .array(let elementType): elementType.needsCoding
+        case .dictionary(let keyType, let valueType): keyType.needsCoding || valueType.needsCoding
+        case .optional(let wrappedType): wrappedType.needsCoding
+        default: false
         }
     }
 

--- a/Tests/UserDefaultMacroTests/Tests/BaseTestCase.swift
+++ b/Tests/UserDefaultMacroTests/Tests/BaseTestCase.swift
@@ -62,7 +62,7 @@ import SwiftSyntaxMacros
                         \(registerDefaultValue)\(userDefaultsInstanceString).\(variable.type.userDefaultsMethodName)(forKey: \(storageKey))\(getterSuffixString)
                     }
                     set {
-                        \(userDefaultsInstanceString).setValue(newValue, forKey: \(storageKey))
+                        \(userDefaultsInstanceString).set(newValue, forKey: \(storageKey))
                     }
                 }
                 """
@@ -92,7 +92,7 @@ import SwiftSyntaxMacros
                         \(userDefaultsInstanceString).\(variable.type.userDefaultsMethodName)(forKey: \(storageKey))\(getterSuffixString)
                     }
                     set {
-                        \(userDefaultsInstanceString).setValue(newValue, forKey: \(storageKey))
+                        \(userDefaultsInstanceString).set(newValue, forKey: \(storageKey))
                     }
                 }
                 """

--- a/Tests/UserDefaultMacroTests/Tests/IntegrationTests.swift
+++ b/Tests/UserDefaultMacroTests/Tests/IntegrationTests.swift
@@ -34,7 +34,7 @@ import Testing
                                 userDefaults.bool(forKey: "isFirstLaunch")
                             }
                             set {
-                                userDefaults.setValue(newValue, forKey: "isFirstLaunch")
+                                userDefaults.set(newValue, forKey: "isFirstLaunch")
                             }
                         }
                         var userName: String {
@@ -42,7 +42,7 @@ import Testing
                                 userDefaults.string(forKey: "userName")!
                             }
                             set {
-                                userDefaults.setValue(newValue, forKey: "userName")
+                                userDefaults.set(newValue, forKey: "userName")
                             }
                         }
                         var loginCount: Int {
@@ -50,7 +50,7 @@ import Testing
                                 userDefaults.integer(forKey: "loginCount")
                             }
                             set {
-                                userDefaults.setValue(newValue, forKey: "loginCount")
+                                userDefaults.set(newValue, forKey: "loginCount")
                             }
                         }
 
@@ -84,7 +84,7 @@ import Testing
                                 userDefaults.string(forKey: "difficulty")!
                             }
                             set {
-                                userDefaults.setValue(newValue, forKey: "difficulty")
+                                userDefaults.set(newValue, forKey: "difficulty")
                             }
                         }
                         var volume: Int {
@@ -92,7 +92,7 @@ import Testing
                                 userDefaults.integer(forKey: "volume")
                             }
                             set {
-                                userDefaults.setValue(newValue, forKey: "volume")
+                                userDefaults.set(newValue, forKey: "volume")
                             }
                         }
 
@@ -126,7 +126,7 @@ import Testing
                                 userDefaults.string(forKey: "user_name")!
                             }
                             set {
-                                userDefaults.setValue(newValue, forKey: "user_name")
+                                userDefaults.set(newValue, forKey: "user_name")
                             }
                         }
                         var email: String {
@@ -134,7 +134,7 @@ import Testing
                                 userDefaults.string(forKey: "email")!
                             }
                             set {
-                                userDefaults.setValue(newValue, forKey: "email")
+                                userDefaults.set(newValue, forKey: "email")
                             }
                         }
 
@@ -165,7 +165,7 @@ import Testing
                                 userDefaults.string(forKey: "apiKey")!
                             }
                             set {
-                                userDefaults.setValue(newValue, forKey: "apiKey")
+                                userDefaults.set(newValue, forKey: "apiKey")
                             }
                         }
 
@@ -202,7 +202,7 @@ import Testing
                                 userDefaults.integer(forKey: "storedValue")
                             }
                             set {
-                                userDefaults.setValue(newValue, forKey: "storedValue")
+                                userDefaults.set(newValue, forKey: "storedValue")
                             }
                         }
 
@@ -240,7 +240,7 @@ import Testing
                                 userDefaults.string(forKey: "optionalString")
                             }
                             set {
-                                userDefaults.setValue(newValue, forKey: "optionalString")
+                                userDefaults.set(newValue, forKey: "optionalString")
                             }
                         }
                         var optionalInt: Int? {
@@ -248,7 +248,7 @@ import Testing
                                 userDefaults.object(forKey: "optionalInt") as? Int
                             }
                             set {
-                                userDefaults.setValue(newValue, forKey: "optionalInt")
+                                userDefaults.set(newValue, forKey: "optionalInt")
                             }
                         }
 
@@ -282,7 +282,7 @@ import Testing
                                 userDefaults.object(forKey: "theme") as! Theme
                             }
                             set {
-                                userDefaults.setValue(newValue, forKey: "theme")
+                                userDefaults.set(newValue, forKey: "theme")
                             }
                         }
 
@@ -343,7 +343,7 @@ import Testing
                                 userDefaults.string(forKey: "userName")!
                             }
                             set {
-                                userDefaults.setValue(newValue, forKey: "userName")
+                                userDefaults.set(newValue, forKey: "userName")
                             }
                         }
 
@@ -393,7 +393,7 @@ import Testing
                                 userDefaults.bool(forKey: "isEnabled")
                             }
                             set {
-                                userDefaults.setValue(newValue, forKey: "isEnabled")
+                                userDefaults.set(newValue, forKey: "isEnabled")
                             }
                         }
 

--- a/Tests/UserDefaultMacroTests/Tests/UserDefaultDataStoreMacroTests.swift
+++ b/Tests/UserDefaultMacroTests/Tests/UserDefaultDataStoreMacroTests.swift
@@ -157,7 +157,56 @@ import Testing
                                 userDefaults.integer(forKey: "volume")
                             }
                             set {
-                                userDefaults.setValue(newValue, forKey: "volume")
+                                userDefaults.set(newValue, forKey: "volume")
+                            }
+                        }
+
+                        private let userDefaults: UserDefaults
+
+                        internal init(userDefaults: UserDefaults = .standard) {
+                            self.userDefaults = userDefaults
+                            userDefaults.register(defaults: ["volume": 100])
+                        }
+                    }
+                    """,
+                macros: testMacrosWithRecord
+            )
+        }
+
+        @Test
+        func testExcludesURLFromRegisterDefaultsAndUsesGetterFallback() {
+            // URL isn't a property-list type, so it's excluded from `register(defaults:)`.
+            // Non-optional URL with a default falls back via `??` in the getter instead.
+            let testMacrosWithRecord: [String: Macro.Type] = [
+                "UserDefaultDataStore": UserDefaultDataStoreMacro.self,
+                "UserDefaultRecord": UserDefaultRecordMacro.self,
+            ]
+            assertMacroExpansion(
+                """
+                @UserDefaultDataStore
+                struct Settings {
+                    @UserDefaultRecord(defaultValue: URL(string: "https://example.com")!)
+                    var endpoint: URL
+                    @UserDefaultRecord(defaultValue: 100)
+                    var volume: Int
+                }
+                """,
+                expandedSource: """
+                    struct Settings {
+                        var endpoint: URL {
+                            get {
+                                userDefaults.url(forKey: "endpoint") ?? URL(string: "https://example.com")!
+                            }
+                            set {
+                                userDefaults.set(newValue, forKey: "endpoint")
+                            }
+                        }
+                        var volume: Int {
+                            get {
+                                userDefaults.integer(forKey: "volume")
+                            }
+                            set {
+                                userDefaults.set(newValue, forKey: "volume")
                             }
                         }
 

--- a/Tests/UserDefaultMacroTests/Tests/UserDefaultPropertyMacroTests.swift
+++ b/Tests/UserDefaultMacroTests/Tests/UserDefaultPropertyMacroTests.swift
@@ -17,9 +17,8 @@ import Testing
             for item in VariableType.allCases {
                 let variable = createAttributedVariable(name: "varName", type: item)
                 let diagnostics: [DiagnosticSpec] =
-                    item.isPlistSafe
-                    ? []
-                    : [
+                    item.needsCoding
+                    ? [
                         DiagnosticSpec(
                             message:
                                 "'\(item.swiftType)' is not directly storable in UserDefaults. Add a 'coding:' parameter to specify Codable encoding/decoding strategy, or ensure the type conforms to NSCoding.",
@@ -31,7 +30,7 @@ import Testing
                                 FixItSpec(message: "Add '@UserDefaultRecord(coding: .plist)' to use Plist encoding"),
                             ]
                         )
-                    ]
+                    ] : []
                 assertMacroExpansion(
                     variable.description,
                     expandedSource: BaseTestCase.expandedPropertySource(for: variable),
@@ -41,9 +40,8 @@ import Testing
 
                 let optionalVariable = createAttributedVariable(name: "varName", type: .optional(wrappedType: item))
                 let optionalDiagnostics: [DiagnosticSpec] =
-                    item.isPlistSafe
-                    ? []
-                    : [
+                    item.needsCoding
+                    ? [
                         DiagnosticSpec(
                             message:
                                 "'\(item.swiftType)?' is not directly storable in UserDefaults. Add a 'coding:' parameter to specify Codable encoding/decoding strategy, or ensure the type conforms to NSCoding.",
@@ -55,7 +53,7 @@ import Testing
                                 FixItSpec(message: "Add '@UserDefaultRecord(coding: .plist)' to use Plist encoding"),
                             ]
                         )
-                    ]
+                    ] : []
                 assertMacroExpansion(
                     optionalVariable.description,
                     expandedSource: BaseTestCase.expandedPropertySource(for: optionalVariable),
@@ -197,6 +195,31 @@ import Testing
                 macros: testMacros,
                 applyFixIts: ["Add 'coding: .plist' to use Plist encoding"],
                 fixedSource: "@UserDefaultProperty(coding: .plist)\nvar theme: Theme?"
+            )
+        }
+
+        // MARK: - URL Tests
+
+        @Test
+        func testExpandsPropertyWithURLDefaultValueUsesNilCoalescingFallback() {
+            // URL is not plist-safe; the macro emits a `?? defaultValue` fallback in the getter
+            // rather than calling `register(defaults:)` (which would reject the non-plist value).
+            assertMacroExpansion(
+                """
+                @UserDefaultProperty(defaultValue: URL(string: "https://example.com")!)
+                var endpoint: URL
+                """,
+                expandedSource: """
+                    var endpoint: URL {
+                        get {
+                            UserDefaults.standard.url(forKey: "endpoint") ?? URL(string: "https://example.com")!
+                        }
+                        set {
+                            UserDefaults.standard.set(newValue, forKey: "endpoint")
+                        }
+                    }
+                    """,
+                macros: testMacros
             )
         }
 

--- a/Tests/UserDefaultMacroTests/Tests/UserDefaultRecordMacroTests.swift
+++ b/Tests/UserDefaultMacroTests/Tests/UserDefaultRecordMacroTests.swift
@@ -15,9 +15,8 @@ import Testing
             for item in VariableType.allCases {
                 let variable = createAttributedVariable(name: "varName", type: item)
                 let diagnostics: [DiagnosticSpec] =
-                    item.isPlistSafe
-                    ? []
-                    : [
+                    item.needsCoding
+                    ? [
                         DiagnosticSpec(
                             message:
                                 "'\(item.swiftType)' is not directly storable in UserDefaults. Add a 'coding:' parameter to specify Codable encoding/decoding strategy, or ensure the type conforms to NSCoding.",
@@ -29,7 +28,7 @@ import Testing
                                 FixItSpec(message: "Add '@UserDefaultRecord(coding: .plist)' to use Plist encoding"),
                             ]
                         )
-                    ]
+                    ] : []
                 assertMacroExpansion(
                     variable.description,
                     expandedSource: BaseTestCase.expandedRecordSource(for: variable),
@@ -39,9 +38,8 @@ import Testing
 
                 let optionalVariable = createAttributedVariable(name: "varName", type: .optional(wrappedType: item))
                 let optionalDiagnostics: [DiagnosticSpec] =
-                    item.isPlistSafe
-                    ? []
-                    : [
+                    item.needsCoding
+                    ? [
                         DiagnosticSpec(
                             message:
                                 "'\(item.swiftType)?' is not directly storable in UserDefaults. Add a 'coding:' parameter to specify Codable encoding/decoding strategy, or ensure the type conforms to NSCoding.",
@@ -53,7 +51,7 @@ import Testing
                                 FixItSpec(message: "Add '@UserDefaultRecord(coding: .plist)' to use Plist encoding"),
                             ]
                         )
-                    ]
+                    ] : []
                 assertMacroExpansion(
                     optionalVariable.description,
                     expandedSource: BaseTestCase.expandedRecordSource(for: optionalVariable),
@@ -163,6 +161,54 @@ import Testing
                 macros: testMacros,
                 applyFixIts: ["Add 'coding: .plist' to use Plist encoding"],
                 fixedSource: "@UserDefaultRecord(coding: .plist)\nvar theme: Theme?"
+            )
+        }
+
+        // MARK: - URL Tests
+
+        @Test
+        func testExpandsRecordWithURLDefaultValueUsesNilCoalescingFallback() {
+            // URL is not plist-safe, so it can't be registered in init. The macro should
+            // emit a `?? defaultValue` fallback in the getter instead of force-unwrapping.
+            assertMacroExpansion(
+                """
+                @UserDefaultRecord(defaultValue: URL(string: "https://example.com")!)
+                var endpoint: URL
+                """,
+                expandedSource: """
+                    var endpoint: URL {
+                        get {
+                            userDefaults.url(forKey: "endpoint") ?? URL(string: "https://example.com")!
+                        }
+                        set {
+                            userDefaults.set(newValue, forKey: "endpoint")
+                        }
+                    }
+                    """,
+                macros: testMacros
+            )
+        }
+
+        @Test
+        func testExpandsRecordWithURLNoDefaultRetainsForceUnwrap() {
+            // Without a default, non-optional URL still force-unwraps — caller opted into that
+            // behavior via the type annotation, matching String/Data/Date semantics.
+            assertMacroExpansion(
+                """
+                @UserDefaultRecord
+                var endpoint: URL
+                """,
+                expandedSource: """
+                    var endpoint: URL {
+                        get {
+                            userDefaults.url(forKey: "endpoint")!
+                        }
+                        set {
+                            userDefaults.set(newValue, forKey: "endpoint")
+                        }
+                    }
+                    """,
+                macros: testMacros
             )
         }
 


### PR DESCRIPTION
## Summary

- Switch generated setters from KVC `setValue(_:forKey:)` to the typed `set(_:forKey:)` overloads. For URL this picks up `set(_:URL?, forKey:)` whose archived form is what `url(forKey:)` reads back — fixing a round-trip bug where written URLs came back as nil.
- Mark `URL` as not plist-safe, so it's excluded from `register(defaults:)` (which crashes on non-plist values). Non-optional URL with a `defaultValue:` now generates a `?? defaultValue` fallback in the getter instead of a force-unwrap that would crash on first read.
- Add a `needsCoding` property on `VariableType` to separate "needs Codable encoding" from "is plist-safe". URL is the case where the two diverge — not plist-safe, but doesn't need coding either.
- Make `VariableType: Sendable` to satisfy Swift 6.3 strict concurrency for `static let allCases`.
- README: new "URL Storage" subsection explaining the behavior.

## Test plan

- [x] `swift test` — all 67 tests pass (3 new URL-specific tests + existing suite)
- [x] `swift package lint-source-code --recursive .` — clean
- [ ] CI green on macOS-26 + Swift 6.2

🤖 Generated with [Claude Code](https://claude.com/claude-code)