### PR TITLE
Use major tags for CI actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,11 +17,11 @@ jobs:
   build:
     runs-on: macos-26
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v6.0.2
       with:
         fetch-depth: 0
     - name: Cache SwiftPM + Swiftly
-      uses: actions/cache@v4
+      uses: actions/cache@v5.0.5
       with:
         path: |
           .build
@@ -30,7 +30,7 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-swift-${{ env.SWIFT_VERSION }}-
     - name: Setup Swift
-      uses: swift-actions/setup-swift@v2
+      uses: swift-actions/setup-swift@v2.4.0
       with:
         swift-version: "${{ env.SWIFT_VERSION }}"
     

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,11 +17,11 @@ jobs:
   build:
     runs-on: macos-26
     steps:
-    - uses: actions/checkout@v6.0.2
+    - uses: actions/checkout@v6
       with:
         fetch-depth: 0
     - name: Cache SwiftPM + Swiftly
-      uses: actions/cache@v5.0.5
+      uses: actions/cache@v5
       with:
         path: |
           .build
@@ -30,7 +30,7 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-swift-${{ env.SWIFT_VERSION }}-
     - name: Setup Swift
-      uses: swift-actions/setup-swift@v2.4.0
+      uses: swift-actions/setup-swift@v2
       with:
         swift-version: "${{ env.SWIFT_VERSION }}"
     

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@
 name: UserDefaultMacro
 
 env:
-  SWIFT_VERSION: "6.3.1"
+  SWIFT_VERSION: "6.2"
 
 on:
   pull_request:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@
 name: UserDefaultMacro
 
 env:
-  SWIFT_VERSION: "6.2"
+  SWIFT_VERSION: "6.3.1"
 
 on:
   pull_request:

--- a/.github/workflows/docc.yml
+++ b/.github/workflows/docc.yml
@@ -24,11 +24,11 @@ jobs:
       contents: read
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v6.0.2
         with:
           fetch-depth: 0
       - name: Cache SwiftPM + Swiftly
-        uses: actions/cache@v4
+        uses: actions/cache@v5.0.5
         with:
           path: |
             .build
@@ -37,19 +37,19 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-swift-${{ env.SWIFT_VERSION }}-
       - name: Setup Swift
-        uses: swift-actions/setup-swift@v2
+        uses: swift-actions/setup-swift@v2.4.0
         with:
           swift-version: "${{ env.SWIFT_VERSION }}"
-      
+
       - name: Verify Swift
         run: swift --version
       - name: Run Build Docs
         run: ./build-docc.sh
       - name: Setup Pages
         id: pages
-        uses: actions/configure-pages@v4
+        uses: actions/configure-pages@v6.0.0
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v4
+        uses: actions/upload-pages-artifact@v5.0.0
         with:
           path: .docs
           name: github-pages
@@ -66,4 +66,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5.0.0

--- a/.github/workflows/docc.yml
+++ b/.github/workflows/docc.yml
@@ -1,7 +1,7 @@
 name: docc
 
 env:
-  SWIFT_VERSION: "6.2"
+  SWIFT_VERSION: "6.3.1"
 
 on:
   push:

--- a/.github/workflows/docc.yml
+++ b/.github/workflows/docc.yml
@@ -1,7 +1,7 @@
 name: docc
 
 env:
-  SWIFT_VERSION: "6.3.1"
+  SWIFT_VERSION: "6.2"
 
 on:
   push:

--- a/.github/workflows/docc.yml
+++ b/.github/workflows/docc.yml
@@ -24,11 +24,11 @@ jobs:
       contents: read
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Cache SwiftPM + Swiftly
-        uses: actions/cache@v5.0.5
+        uses: actions/cache@v5
         with:
           path: |
             .build
@@ -37,7 +37,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-swift-${{ env.SWIFT_VERSION }}-
       - name: Setup Swift
-        uses: swift-actions/setup-swift@v2.4.0
+        uses: swift-actions/setup-swift@v2
         with:
           swift-version: "${{ env.SWIFT_VERSION }}"
 
@@ -47,9 +47,9 @@ jobs:
         run: ./build-docc.sh
       - name: Setup Pages
         id: pages
-        uses: actions/configure-pages@v6.0.0
+        uses: actions/configure-pages@v6
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v5.0.0
+        uses: actions/upload-pages-artifact@v5
         with:
           path: .docs
           name: github-pages
@@ -66,4 +66,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v5.0.0
+        uses: actions/deploy-pages@v5

--- a/Sources/UserDefaultMacro/Models/VariableType.swift
+++ b/Sources/UserDefaultMacro/Models/VariableType.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SwiftSyntax
 
-indirect enum VariableType: CaseIterable {
+indirect enum VariableType: CaseIterable, Sendable {
     static let allCases: [VariableType] = [
         .int, .double, .float, .bool, .string, .url, .data, .date, .array(elementType: .int),
         .dictionary(keyType: .int, valueType: .int), .object(entityTypeName: "SomeEntityName"),


### PR DESCRIPTION
## Summary

- switch GitHub Actions workflow references to major-version tags instead of exact patch pins
- keep `swift-actions/setup-swift` on stable `v2` and keep CI on Swift `6.2`
- avoid the current `setup-swift@v2` failure when requesting Swift `6.3.1`

## Details

This branch originally pinned actions to exact versions and bumped CI to Swift `6.3.1`. That combination broke because `swift-actions/setup-swift@v2` does not currently resolve Swift `6.3.1`, even though the toolchain exists upstream.

The final version of this PR keeps the stable `setup-swift` major version, aligns workflow `SWIFT_VERSION` with the package's current Swift tools version, and uses major-version action references for easier maintenance.

| Action | Final version |
|---|---|
| `actions/checkout` | `v6` |
| `actions/cache` | `v5` |
| `swift-actions/setup-swift` | `v2` |
| `actions/configure-pages` | `v6` |
| `actions/upload-pages-artifact` | `v5` |
| `actions/deploy-pages` | `v5` |

## Test plan

- [ ] GitHub Actions build workflow passes with Swift `6.2`
- [ ] GitHub Actions DocC workflow passes with Swift `6.2`