### PR TITLE
Bump swift-syntax to 0.603.1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,7 +38,7 @@ jobs:
       run: swift --version
     
     - name: Check formatting
-      run: swift package lint-source-code --recursive .
+      run: swift-format lint --recursive Sources/ Tests/
 
     - name: Build code
       run: swift build -v -Xswiftc -warnings-as-errors

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,11 +15,11 @@ UserDefaultMacro is a Swift macro package that generates boilerplate code for `U
 ### Code Formatting
 
 ```bash
-# Format all Swift files (requires permission)
-swift package --allow-writing-to-package-directory format-source-code --recursive .
+# Format all Swift files (in-place)
+swift-format format --recursive --in-place Sources/ Tests/
 
 # Check formatting without making changes (for CI)
-swift package lint-source-code --recursive .
+swift-format lint --recursive Sources/ Tests/
 ```
 
 ### Build & Test
@@ -60,7 +60,7 @@ swift package clean
 
 ### Code Formatting
 
-This project uses Apple's **swift-format** (integrated via SwiftPM plugin) for consistent code style:
+This project uses Apple's **swift-format** (bundled with the Swift toolchain) for consistent code style:
 - Maximum line width: 120 characters (see `.swift-format`)
 - Omit explicit `return` in single-expression functions
 - 4-space indentation
@@ -73,12 +73,12 @@ Configuration is in `.swift-format` file (JSON format).
 1. Write it in compliance with the formatting rules from the start (preferred), OR
 2. After making changes, run the formatter before committing:
 ```bash
-swift package --allow-writing-to-package-directory format-source-code --recursive .
+swift-format format --recursive --in-place Sources/ Tests/
 ```
 
-**Never commit code that would fail** `swift package lint-source-code --recursive .`
+**Never commit code that would fail** `swift-format lint --recursive Sources/ Tests/`
 
-**No external installation required** - swift-format is included as a package dependency.
+**No installation required** - `swift-format` is bundled with the Swift toolchain.
 
 ## Package Structure
 
@@ -149,8 +149,8 @@ Total: 34 tests with 100% pass rate
 ## Swift Version Requirements
 
 - Requires Swift 6.2 (specified in Package.swift)
-- Uses swift-syntax from 602.0.0 (SPM semver range)
-- Uses swift-format from 602.0.0 (SPM semver range, matched to swift-syntax series)
+- Uses swift-syntax from 603.0.1 (SPM semver range)
+- Uses swift-format bundled with the Swift toolchain (no package dependency)
 - Supports macOS 10.15+, iOS 13+, tvOS 13+, watchOS 6+, macCatalyst 13+
 
 ## CI/CD
@@ -158,7 +158,7 @@ Total: 34 tests with 100% pass rate
 - Uses GitHub Actions with macOS-26 runner
 - Installs Swift 6.2 via Swiftly
 - Runs formatting checks, build, tests, and DocC generation on PRs to main branch
-- Uses swift-format plugin (no external tool installation required)
+- Uses swift-format bundled with the Swift toolchain for formatting checks
 
 ## Important Design Decisions
 

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,24 +1,6 @@
 {
-  "originHash" : "fd448134884034d63856c3252aee162a3fd032cd13a4223a140767704368ca8f",
+  "originHash" : "ee48ed8a58449c0041bff37939de978aef004022e3e309a9462e797609ffd07f",
   "pins" : [
-    {
-      "identity" : "swift-argument-parser",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-argument-parser.git",
-      "state" : {
-        "revision" : "626b5b7b2f45e1b0b1c6f4a309296d1d21d7311b",
-        "version" : "1.7.1"
-      }
-    },
-    {
-      "identity" : "swift-cmark",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/swiftlang/swift-cmark.git",
-      "state" : {
-        "revision" : "924936d0427cb25a61169739a7660230bffa6ea6",
-        "version" : "0.8.0"
-      }
-    },
     {
       "identity" : "swift-docc-plugin",
       "kind" : "remoteSourceControl",
@@ -38,30 +20,12 @@
       }
     },
     {
-      "identity" : "swift-format",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-format.git",
-      "state" : {
-        "revision" : "62eaad2822b865407b8cde56c36386c00800f7ec",
-        "version" : "602.0.0"
-      }
-    },
-    {
-      "identity" : "swift-markdown",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-markdown.git",
-      "state" : {
-        "revision" : "3c6f9523da3a1ec2fd829673e472d95b8097a3b8",
-        "version" : "0.8.0"
-      }
-    },
-    {
       "identity" : "swift-syntax",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swiftlang/swift-syntax.git",
       "state" : {
-        "revision" : "4799286537280063c85a32f09884cfbca301b1a1",
-        "version" : "602.0.0"
+        "revision" : "9de99a78f099e59caf2b2beec65a4c45d54b2081",
+        "version" : "603.0.1"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -11,9 +11,8 @@ let package = Package(
         .executable(name: "UserDefaultClient", targets: ["UserDefaultClient"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/swiftlang/swift-syntax.git", from: "602.0.0"),
+        .package(url: "https://github.com/swiftlang/swift-syntax.git", from: "603.0.1"),
         .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.5.0"),
-        .package(url: "https://github.com/apple/swift-format.git", from: "602.0.0"),
     ],
     targets: [
         // Macro implementation that performs the source transformation of a macro.

--- a/README.md
+++ b/README.md
@@ -323,21 +323,21 @@ If you have any idea to improve this repo, please feel free to fork and send a p
 
 #### Code Style
 
-This project uses Apple's official [swift-format](https://github.com/apple/swift-format) (integrated via SwiftPM plugin) to maintain consistent code formatting. The configuration is in `.swift-format` with the following key rules:
+This project uses Apple's official [swift-format](https://github.com/apple/swift-format) (bundled with the Swift toolchain) to maintain consistent code formatting. The configuration is in `.swift-format` with the following key rules:
 - Omit explicit `return` in single-expression functions
 - 120 character line width
 - 4-space indentation
 - Single-line property getters
 - Ordered imports
 
-**No external installation required** - swift-format is included as a package dependency.
+**No installation required** - `swift-format` is bundled with the Swift toolchain.
 
 ```bash
 # Format code
-swift package --allow-writing-to-package-directory format-source-code --recursive .
+swift-format format --recursive --in-place Sources/ Tests/
 
 # Check formatting (CI)
-swift package lint-source-code --recursive .
+swift-format lint --recursive Sources/ Tests/
 ```
 
 ### License


### PR DESCRIPTION
- Bump `swift-syntax` to `603.0.1`
- Remove `swift-format` since it was tightly coupled with `swift-syntax` lower version